### PR TITLE
Add image tags to deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,9 @@ variables:
   # improved performance.
   DOCKER_DRIVER: overlay2
 
+before_script:
+  - export IMAGE_TAG=${CI_BUILD_REF_NAME}-$(git describe --tags --always)-$CI_BUILD_ID
+
 services:
   - docker:dind
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ terraform-%:
 	terraform $(*) \
 		-var cluster=$(CLUSTER) \
 		-var aws_region=$(AWS_DEFAULT_REGION) \
+		-var image_tag=$(IMAGE_TAG) \
 		$(TERRAFORM_OPTIONS)
 
 .PHONY: plan
@@ -81,15 +82,15 @@ plugin:
 
 .PHONY: image
 image: all.yaml grafana.ini gcp-credentials.json
-	docker build -t $(APP_NAME) .
+	docker build -t $(APP_NAME):$(IMAGE_TAG) .
 	docker pull abutaha/aws-es-proxy:0.8
 
 .PHONY: publish
 publish:
-	docker tag $(APP_NAME):latest $(GRAFANA_IMAGE_NAME)
-	docker push $(GRAFANA_IMAGE_NAME)
-	docker tag abutaha/aws-es-proxy:0.8 $(ES_PROXY_IMAGE_NAME)
-	docker push $(ES_PROXY_IMAGE_NAME)
+	docker tag $(APP_NAME):$(IMAGE_TAG) $(GRAFANA_IMAGE_NAME):$(IMAGE_TAG)
+	docker push $(GRAFANA_IMAGE_NAME):$(IMAGE_TAG)
+	docker tag abutaha/aws-es-proxy:0.8 $(ES_PROXY_IMAGE_NAME):$(IMAGE_TAG)
+	docker push $(ES_PROXY_IMAGE_NAME):$(IMAGE_TAG)
 
 .PHONY: deploy-app
 deploy-app:

--- a/docker-compose.tf
+++ b/docker-compose.tf
@@ -7,7 +7,7 @@ output "docker-compose.yml" {
 version: '2'
 services:
   grafana:
-    image: ${aws_ecr_repository.grafana.repository_url}:latest
+    image: ${aws_ecr_repository.grafana.repository_url}:${var.image_tag}
     ports:
       - "3000:3000"
     logging:
@@ -17,7 +17,7 @@ services:
         awslogs-region: ${var.aws_region}
         awslogs-stream-prefix: grafana
   es-proxy:
-    image: ${aws_ecr_repository.es_proxy.repository_url}:latest
+    image: ${aws_ecr_repository.es_proxy.repository_url}:${var.image_tag}
     environment:
       - AWS_ACCESS_KEY_ID=${aws_iam_access_key.grafana_datasource.id}
       - AWS_SECRET_ACCESS_KEY=${aws_iam_access_key.grafana_datasource.secret}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,5 @@
 variable "cluster" {}
 
 variable "aws_region" {}
+
+variable "image_tag" {}


### PR DESCRIPTION
Building and deploying images should be namespaced by branch, git hash, and build to ensure that the version built in a given pipeline is the version deployed in the pipeline.